### PR TITLE
Moved simulators and many tests from cloud-scanner-azure to cloud-scanner

### DIFF
--- a/cloud_scanner/rules/example_rules.py
+++ b/cloud_scanner/rules/example_rules.py
@@ -31,10 +31,10 @@ class ExampleRule2(TagUpdateRule):
 @register_rule(create_rule)
 class ExampleRule3(TagUpdateRule):
     def check_condition(self, resource: Resource) -> bool:
-        return True if "nike" in resource.name else False
+        return True if "Microsoft" in resource.name else False
 
     def get_tags(self, resource: Resource):
-        return {"Company": "Nike"}
+        return {"Company": "Microsoft"}
 
 
 @register_rule(create_rule)

--- a/cloud_scanner/simulators/__init__.py
+++ b/cloud_scanner/simulators/__init__.py
@@ -1,0 +1,5 @@
+from .account_service_simulator import AccountServiceSimulator
+from .container_storage_simulator import MockBlobStorageSimulator
+from .queue_simulator import QueueSimulator
+from .resource_service_simulator import ResourceServiceSimulator
+from .table_storage_simulator import TableStorageSimulator

--- a/cloud_scanner/simulators/account_service_simulator.py
+++ b/cloud_scanner/simulators/account_service_simulator.py
@@ -1,0 +1,31 @@
+from cloud_scanner.contracts.account_service import AccountService
+from cloud_scanner.contracts.account_service_factory import register_account_service
+
+
+@register_account_service("simulator", lambda: AccountServiceSimulator())
+class AccountServiceSimulator(AccountService):
+    """
+    Simulator of AccoutService
+    """
+    def get_accounts(self):
+        """
+        Get fake accounts
+        :return: List of fake accounts
+        [
+            {
+                'subscriptionId': '...',
+                'displayName': '...'
+            },
+            ...
+        ]
+        """
+        return [
+            {
+                "subscriptionId": "00000000-0000-0000-0000-000000000000",
+                "displayName": "Sub1"
+            },
+            {
+                "subscriptionId": "00000000-0000-0000-0000-000000000001",
+                "displayName": "Sub2"
+            }
+        ]

--- a/cloud_scanner/simulators/container_storage_simulator.py
+++ b/cloud_scanner/simulators/container_storage_simulator.py
@@ -1,0 +1,104 @@
+import logging
+
+from cloud_scanner.contracts.storage_container import StorageContainer
+from cloud_scanner.contracts.storage_container_factory import register_storage_container
+
+
+class MockBlobStorageOutput:
+    """
+    Simulator of blob storage output
+    """
+    def __init__(self, name, content):
+        self._name = name
+        self._content = str(content)
+
+    @property
+    def name(self):
+        """
+        :return: str Name of blob file
+        """
+        return self._name
+
+    @property
+    def content(self):
+        """
+        :return: str Content of blob file
+        """
+        return self._content
+
+
+@register_storage_container("simulator", lambda: MockBlobStorageSimulator())
+class MockBlobStorageSimulator(StorageContainer):
+    """
+    Simulator of BlobStorage
+    """
+    def __init__(self):
+
+        config_content = '''{
+            "providers":[
+                {
+                    "type":"simulator",
+                    "resourceTypes": [{"typeName": "Microsoft.Compute/virtualMachines"}],
+                    "subscriptions": [
+                        {
+                            "subscriptionId": "00000000-0000-0000-0000-000000000001", 
+                            "displayName": "Simulator Sub 1"
+                        },
+                        {
+                            "subscriptionId": "00000000-0000-0000-0000-000000000002", 
+                            "displayName": "Simulator Sub 2"
+                        }
+                    ]
+                }]
+        }'''
+
+        list_of_entries = []
+        latest = MockBlobStorageOutput('config-2018-08-29-10-20-49.json ', config_content)
+        entry1 = MockBlobStorageOutput('config-2018-08-20-12-33-48.json ', '{}')
+        entry2 = MockBlobStorageOutput('config-2018-08-21-09-41-05.json ', '{}')
+        entry3 = MockBlobStorageOutput('config-2018-08-21-09-42-12.json ', '{}')
+        entry4 = MockBlobStorageOutput('config-2018-08-22-11-41-49.json ', '{}')
+        entry5 = MockBlobStorageOutput('config-2018-08-22-11-50-38.json ', '{}')
+
+        list_of_entries.append(latest)
+        list_of_entries.append(entry1)
+        list_of_entries.append(entry2)
+        list_of_entries.append(entry3)
+        list_of_entries.append(entry4)
+        list_of_entries.append(entry5)
+
+        self._entries = list_of_entries
+        self._latest_entry = latest
+
+    def get_blob_to_text(self, config):
+        """
+        :param config: Config file to get text from
+        :return: Text contained in config
+        """
+        # ensure the latest config was picked
+        if config is not self._latest_entry.name:
+            logging.error("The picked config is not the latest. Returned: %s, latest: %s",
+                          config, self._latest_entry.name)
+            return None
+        return self._latest_entry
+
+    def list_blobs(self):
+        """
+        :return: List of blob files
+        """
+        return self._entries
+
+    def get_latest_config(self):
+        """
+        :return: Latest config file
+        """
+        return self._latest_entry
+
+    def upload_text(self, filename, text):
+        """
+        Fake call to upload text
+        :param filename: name of new config file
+        :param text: text to put in config file
+        :return: None
+        """
+        logging.info("upload_text was called.")

--- a/cloud_scanner/simulators/queue_simulator.py
+++ b/cloud_scanner/simulators/queue_simulator.py
@@ -1,0 +1,40 @@
+import collections
+
+from cloud_scanner.contracts.queue import Queue
+from cloud_scanner.contracts.queue_factory import register_queue_service
+
+
+@register_queue_service("simulator", lambda queue_name: QueueSimulator(queue_name))
+class QueueSimulator(Queue):
+    """
+    Simulator of queue service
+    """
+
+    def __init__(self, queue_name, config=None):
+        self._queue_name = queue_name
+        self._queue = collections.deque()
+
+    def __len__(self):
+        return len(self._queue)
+
+    def push(self, message):
+        """
+        Push new message to queue
+        :param message: message to push
+        :return: None
+        """
+        self._queue.append(message)
+
+    def pop(self):
+        """
+        Pop message off of queue
+        :return: Message popped
+        """
+        return self._queue.popleft()
+
+    def peek(self):
+        """
+        Peek at message, but don't pop
+        :return: Message peeked
+        """
+        return self._queue[0]

--- a/cloud_scanner/simulators/resource_service_simulator.py
+++ b/cloud_scanner/simulators/resource_service_simulator.py
@@ -1,0 +1,74 @@
+from cloud_scanner.contracts import Resource
+from cloud_scanner.contracts.resource_service import ResourceService, ResourceFilter
+from cloud_scanner.contracts.resource_service_factory import register_resource_service
+
+
+@register_resource_service("simulator", lambda subscription_id: ResourceServiceSimulator())
+class ResourceServiceSimulator(ResourceService):
+    """
+    Simulator of resource service
+    """
+    @property
+    def name(self):
+        """
+        :return: 'simulator'
+        """
+        return "simulator"
+
+    resources = [{
+                'id': '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yyyyyyyyyyyy/providers/microsoft.insights/components/wwwwwwwwwwww',
+                'name': 'wwwwwwwwwwww',
+                'type': 'microsoft.insights/components',
+                'location': 'southcentralus',
+                'tags': {
+                    'hidden-link:/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yyyyyyyyyyyy/providers/Microsoft.Web/sites/wwwwwwwwwwww': 'Resource'
+                },
+                'kind': 'web'
+                }, {
+                'id': '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yyyyyyyyyyyy/providers/Microsoft.ServiceBus/namespaces/wwwwwwwwwwww',
+                'name': 'wwwwwwwwwwww',
+                'type': 'Microsoft.ServiceBus/namespaces',
+                'location': 'southcentralus',
+                'tags': {},
+                'sku': {
+                    'name': 'Standard',
+                    'tier': 'Standard'
+                }
+                }, {
+                'id': '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yyyyyyyyyyyy/providers/Microsoft.Storage/storageAccounts/wwwwwwwwwwww',
+                'name': 'wwwwwwwwwwww',
+                'type': 'Microsoft.Storage/storageAccounts',
+                'location': 'southcentralus',
+                'tags': {},
+                'kind': 'Storage',
+                'sku': {
+                    'name': 'Standard_LRS',
+                    'tier': 'Standard'
+                }
+                }, {
+                'id': '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yyyyyyyyyyyy/providers/Microsoft.Web/serverFarms/wwwwwwwwwwww',
+                'name': 'wwwwwwwwwwww',
+                'type': 'Microsoft.Web/serverFarms',
+                'location': 'southcentralus',
+                'kind': 'functionapp'
+                }, {
+                'id': '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/yyyyyyyyyyyy/providers/Microsoft.Web/sites/wwwwwwwwwwww',
+                'name': 'wwwwwwwwwwww',
+                'type': 'Microsoft.Web/sites',
+                'location': 'southcentralus',
+                'kind': 'functionapp'
+                }]
+
+    def get_resources(self, filter: ResourceFilter=None):
+        """
+        Get list of AzureResources from service
+        :param filter: Filter object to filter resources
+        :return: List of AzureResource objects
+        """
+        return [Resource(resource) for resource in self.resources]
+
+    def update_resource(self, resource):
+        return None
+
+    def get_filter(self, payload) -> ResourceFilter:
+        pass

--- a/cloud_scanner/simulators/table_storage_simulator.py
+++ b/cloud_scanner/simulators/table_storage_simulator.py
@@ -1,0 +1,60 @@
+from cloud_scanner.contracts.table_storage import TableStorage
+from cloud_scanner.contracts.resource import Resource
+from cloud_scanner.contracts.resource_storage_factory import register_resource_storage
+from cloud_scanner.helpers import entry_storage
+
+
+@register_resource_storage("simulator", lambda: TableStorageSimulator())
+class TableStorageSimulator(TableStorage):
+    """
+    Simulator of TableStorage service
+    """
+
+    def __init__(self):
+        self._data = dict()
+
+        self._resources = [
+            { "id": '/resources/type1/resource1', "accountId": "account1", "type": "Microsoft.Storage/virtualMachine", "name": "resource1", "providerType": "simulator", "location": "location1"},
+            { "id": '/resources/type1/resource2', "accountId": "account2", "type": "Microsoft.Storage/virtualMachine", "name": "resource2", "providerType": "simulator", "location": "location2"},
+            { "id": '/resources/type1/resource3', "accountId": "account2", "type": "Microsoft.Storage/virtualMachine", "name": "resource3", "providerType": "simulator", "location": "location3"},
+            { "id": '/resources/type1/resource4', "accountId": "account3", "type": "Microsoft.Storage/virtualMachine", "name": "resource4", "providerType": "simulator", "location": "location4"},
+            { "id": '/resources/type1/resource5', "accountId": "account4", "type": "Microsoft.Storage/virtualMachine", "name": "resource5", "providerType": "simulator", "location": "location5"},
+        ]
+
+    # entry is of json type
+    def write(self, resource):
+        """
+        Write resource to storage
+        :param resource: Resource to write
+        :return: None
+        """
+        entry = resource.to_dict()
+        prepared = entry_storage.EntryOperations.prepare_entry_for_insert(entry)
+        key = entry['PartitionKey'] + '-' + entry['RowKey']
+        self._data[key] = prepared
+
+    def query(self, partition_key, row_key):
+        """
+        Get element from table storage
+        :param partition_key: Partition key of resource
+        :param row_key: Row key of resource
+        :return: Resource if found
+        """
+        task = self._data[partition_key + '-' + row_key]
+        return task
+
+    def query_list(self):
+        """
+        Get all resources in storage
+        :return: List of Resource objects
+        """
+        return [Resource(resource) for resource in self._resources]
+
+    def delete(self, partition_key, row_key):
+        """
+        Delete resource from storage
+        :param partition_key: Partition key of resource
+        :param row_key: Row key of resource
+        :return: None
+        """
+        del self._data[partition_key + '-' + row_key]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .unittest_base import TestCase, FakeQueueMessage

--- a/tests/test_account_service_factory.py
+++ b/tests/test_account_service_factory.py
@@ -1,0 +1,46 @@
+import os
+
+from cloud_scanner.contracts import AccountServiceFactory, AccountService, register_account_service
+from unittest.mock import patch
+from .unittest_base import TestCase
+
+
+def create_func():
+    return AccountServiceMock()
+
+@register_account_service('test', create_func)
+class AccountServiceMock(AccountService):
+    pass
+
+class TestAccountServiceFactory(TestCase):
+    def test_simulator_account_service(self):
+        account_service = AccountServiceFactory.create("simulator")
+        self.assertIsNotNone(account_service)
+        self.assertEqual(type(account_service).__name__, "AccountServiceSimulator")
+
+    @patch.object(AccountServiceFactory, 'register_factory')
+    def test_register_account_service_decorator(self, mock_register_factory):
+        decorator = register_account_service('test', create_func)
+        decorator(AccountServiceFactory)
+
+        mock_register_factory.assert_called_once_with('test', create_func)
+
+        account_service = AccountServiceFactory.create("test")
+        self.assertIsNotNone(account_service)
+        self.assertEqual(type(account_service).__name__, "AccountServiceMock")
+
+    def test_unknown_provider(self):
+        test_error = None
+
+        try:
+            AccountServiceFactory.create("unknown")
+        except Exception as create_error:
+            test_error = create_error
+
+        self.assertFalse(test_error is None, "Expected error to be thrown for invalid provider")
+
+    def test_get_providers(self):
+        providers = AccountServiceFactory.get_providers()
+        self.assertGreater(len(providers), 0)
+
+

--- a/tests/test_config_generator.py
+++ b/tests/test_config_generator.py
@@ -1,0 +1,41 @@
+import json
+
+from cloud_scanner.simulators import MockBlobStorageSimulator
+from cloud_scanner.contracts import CloudConfigGenerator
+from .unittest_base import TestCase
+
+
+class CloudConfigGeneratorTest(TestCase):
+
+    types = ['vm', 'storage']
+    provider_types = ['simulator']
+
+    expected_config = {
+        "providers": [{
+            "type": "simulator",
+            "subscriptions": [
+                {
+                    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+                    "displayName": "Sub1"},
+                {
+                    "subscriptionId": "00000000-0000-0000-0000-000000000001",
+                    "displayName": "Sub2"
+                }
+            ],
+            "resourceTypes": [
+                {"typeName": "vm"},
+                {"typeName": "storage"}
+            ]
+        }]
+    }
+
+    def test_cloud_generator(self):
+        container = MockBlobStorageSimulator()
+        config_generator = CloudConfigGenerator(container)
+        config = config_generator.generate_config(
+            self.provider_types, self.types)
+
+        # Asserting both string comparison and dictionary comparison
+        # just to show serialization/deserialization isn't a problem
+        self.assertEqual(config, json.dumps(self.expected_config))
+        self.assertDictEqual(json.loads(config), self.expected_config)

--- a/tests/test_example_rules.py
+++ b/tests/test_example_rules.py
@@ -1,0 +1,54 @@
+import os
+
+from cloud_scanner.contracts import QueueFactory, Resource
+from .unittest_base import TestCase
+
+
+class TestExampleRules(TestCase):
+    def setUp(self):
+        os.environ["QUEUE_TYPE"] = "simulator"
+        os.environ["TAG_UPDATES_QUEUE_NAME"] = "test-queue-name"
+        self._queue = QueueFactory.create("test-queue-name")
+
+        resource_json = { "id": '/resources/type1/resource1', "accountId": "account1", "type": "Microsoft.Storage/virtualMachine", "name": "resource1", "providerType": "simulator", "location": "location1"}
+        self._resource = Resource(resource_json)
+
+    def test_rule_1(self):
+        from cloud_scanner.rules import ExampleRule1
+        rule1 = ExampleRule1(self._queue)
+        result = rule1.check_condition(self._resource)
+        count = rule1.process(self._resource)
+
+        self.assertFalse(result)
+        self.assertEqual(count, 0)
+
+    def test_rule_2(self):
+        from cloud_scanner.rules import ExampleRule2
+        rule2 = ExampleRule2(self._queue)
+        result = rule2.check_condition(self._resource)
+        count = rule2.process(self._resource)
+
+        self.assertTrue(result)
+        self.assertEqual(count, 1)
+
+    def test_rule_3(self):
+        from cloud_scanner.rules import ExampleRule3
+        rule3 = ExampleRule3(self._queue)
+        result = rule3.check_condition(self._resource)
+        count = rule3.process(self._resource)
+
+        self.assertFalse(result)
+        self.assertEqual(count, 0)
+
+    def test_rule_4(self):
+        from cloud_scanner.rules import ExampleRule4
+        rule4 = ExampleRule4(self._queue)
+        result = rule4.check_condition(self._resource)
+        count = rule4.process(self._resource)
+
+        self.assertTrue(result)
+        self.assertEqual(count, 1)
+
+
+
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,133 @@
+import logging
+import json
+import pytest
+import unittest
+
+from .unittest_base import FakeQueueMessage
+from cloud_scanner.services.resource_scanner import ResourceScanner
+from cloud_scanner.services.task_scheduler import TaskScheduler
+from cloud_scanner.services.resource_storage import ResourceStorage
+from cloud_scanner.contracts import ResourceStorageFactory, QueueFactory
+
+from unittest import mock
+
+from cloud_scanner.simulators import QueueSimulator
+
+@pytest.mark.skip(reason="Integration test")
+class IntegrationTest(unittest.TestCase):
+
+    # Used when explicitly testing a task
+    _test_subscription = '12341234-0000-0000-0000-123412341234'
+
+    # 
+    _write_to_storage = True
+
+    def schedule_tasks(self):
+        result_messages = []
+
+        def push_intercept(msg):
+            queue_msg = FakeQueueMessage(bytes(msg, 'utf-8'))
+            result_messages.append(queue_msg)
+        
+        with mock.patch.object(QueueSimulator, "push", side_effect=push_intercept):
+            logging.info("Running Task Scheduler")
+            TaskScheduler.execute()
+        
+        # Will fail if no tasks were configured
+        assert(result_messages)
+
+        test_msg = result_messages[0].get_json()
+        logging.info(f"Inspecting first message: {test_msg}")
+        assert(test_msg['providerType'])
+        assert(test_msg['subscriptionId'])
+        assert(test_msg['typeName'])
+        
+        return result_messages
+    
+    @staticmethod
+    def _create_dummy_task(sub_id, resource_type, provider='azure'):
+        dummy_task = {
+            'providerType': provider,
+            'subscriptionId': sub_id,
+            'typeName': resource_type
+        }
+        task_string = json.dumps(dummy_task)
+        msg = FakeQueueMessage(bytes(task_string, 'utf-8'))
+        return msg
+
+    def scan_resource_test(self, task_msg):
+        result_messages = []
+
+        def push_intercept(msg):
+            queue_msg = FakeQueueMessage(bytes(msg, 'utf-8'))
+            result_messages.append(queue_msg)
+        
+        with mock.patch.object(QueueFactory, "create") as cm:
+            fake_push = mock.MagicMock(side_effect=push_intercept)
+            fake_queue = mock.MagicMock(push=fake_push)
+            cm.return_value = fake_queue
+
+            logging.info(f"Running Resource Scanner")
+            ResourceScanner.process_queue_message(task_msg)
+        
+        # Will fail if no resources were found
+        assert(result_messages)
+
+        test_msg = result_messages[0].get_json()
+        logging.info(f"Inspecting first message: {test_msg}")
+        assert(test_msg["id"])
+        assert(test_msg["name"])
+        assert(test_msg["type"])
+        assert(test_msg["location"])
+        
+        return result_messages
+    
+    def store_resource_test(self, resource_msg):
+        if self._write_to_storage:
+            ResourceStorage.process_queue_message(resource_msg)
+            return
+        
+        written_resources = []
+        def write_intercept(resource):
+            logging.info(f"Intercepted storage write {resource.to_normalized_dict()}")
+            written_resources.append(resource)
+
+        with mock.patch.object(ResourceStorageFactory, "create") as cm:
+            fake_write = mock.MagicMock(side_effect=write_intercept)
+            fake_storage = mock.MagicMock(write=fake_write)
+            cm.return_value = fake_storage
+
+            logging.info(f"Running Resource Storage")
+            ResourceStorage.process_queue_message(resource_msg)
+        
+        assert(written_resources)
+        normalized_resource = written_resources[0].to_normalized_dict()
+
+        assert(normalized_resource["ARN"])
+        assert(normalized_resource["ResourceId"])
+        assert(normalized_resource["ResourceType"])
+        assert(normalized_resource["Region"])
+    
+    def _run_task(self, task):
+        resources = self.scan_resource_test(task)
+
+        for resource_msg in resources:
+            self.store_resource_test(resource_msg)
+
+    # Full integration test of everything defined by configuration
+    def test_integration(self):
+        tasks = self.schedule_tasks()
+
+        for task in tasks:
+            self._run_task(task)
+    
+    # Only test storage accounts
+    def test_storage_account(self):
+        storage_task = self._create_dummy_task(self._test_subscription, 'Microsoft.Storage/storageAccounts')
+        self._run_task(storage_task)
+    
+    # Only test virtual Machines
+    def test_virtual_machines(self):
+        storage_task = self._create_dummy_task(self._test_subscription, 'Microsoft.Compute/virtualMachines')
+        
+        self._run_task(storage_task)

--- a/tests/test_resource_scanner.py
+++ b/tests/test_resource_scanner.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+from cloud_scanner.simulators import ResourceServiceSimulator, QueueSimulator
+from cloud_scanner.services.resource_scanner import ResourceScanner, ResourceTaskProcessor
+from .unittest_base import TestCase, FakeQueueMessage
+from cloud_scanner.config import ProcessConfig
+
+
+class TestScanResources(TestCase):
+    def setUp(self):
+        os.environ["STORAGE_CONTAINER_TYPE"] = "simulator"
+        os.environ["RESOURCE_STORAGE_TYPE"] = "simulator"
+        os.environ["QUEUE_TYPE"] = "simulator"
+        os.environ["PAYLOAD_QUEUE_NAME"] = "test-queue"
+
+    def test_simulator_task(self):
+        json_data = '''
+            {
+                "providerType": "simulator",
+                "subscriptionId": "00000000-0000-0000-0000-000000000001",
+                "typeName": "Microsoft.Compute/virtualMachines"
+            }
+        '''
+        message = FakeQueueMessage(bytes(json_data, 'utf-8'))
+        count = ResourceScanner.process_queue_message(message)
+
+        self.assertEqual(count, 1)
+
+    def test_task_processor(self):
+        data = {
+            "subscriptionId" : "12345678-0000-0000-0000-123412341234",
+            "typeName" : "storage"
+        }
+        resource_service = ResourceServiceSimulator()
+        queue = QueueSimulator("test_queue")
+
+        # Get the expected resources from the provider
+        resources = resource_service.get_resources(data["subscriptionId"])
+
+        task_processor = ResourceTaskProcessor(resource_service, queue)
+        task_processor.execute(data)
+
+        item = queue.pop()
+
+        self.assertEqual(len(json.loads(item)), len(resources))
+
+    def test_batching(self):
+        key = 'RESOURCE_BATCH_SIZE'
+        if key in os.environ:
+            del os.environ[key]
+        process_config = ProcessConfig()
+        self.assertEqual(16, process_config.batch_size)
+
+        os.environ[key] = '100'
+        self.assertEqual(100, process_config.batch_size)
+
+

--- a/tests/test_resource_service_factory.py
+++ b/tests/test_resource_service_factory.py
@@ -1,0 +1,42 @@
+import os
+
+from cloud_scanner.contracts import ResourceServiceFactory, register_resource_service, ResourceService
+from .unittest_base import TestCase
+from unittest.mock import patch
+
+
+def create_func(subscription_id):
+    return ResourceServiceMock()
+
+
+@register_resource_service('test', create_func)
+class ResourceServiceMock():
+    pass
+
+
+class TestResourceServiceFactory(TestCase):
+    def test_simulator_provider(self):
+        service = ResourceServiceFactory.create("simulator", "00000000-0000-0000-0000-000000000000")
+        self.assertFalse(service is None)
+        self.assertEqual("ResourceServiceSimulator", type(service).__name__)
+
+    @patch.object(ResourceServiceFactory, 'register_factory')
+    def test_register_resource_service_decorator(self, mock_register_factory):
+        decorator = register_resource_service('test', create_func)
+        decorator(ResourceServiceFactory)
+
+        mock_register_factory.assert_called_once_with('test', create_func)
+
+        resource_service = ResourceServiceFactory.create("test", "00000000-0000-0000-0000-000000000000")
+        self.assertIsNotNone(resource_service)
+        self.assertEqual(type(resource_service).__name__, "ResourceServiceMock")
+
+    def test_unknown_provider(self):
+        test_error = None
+
+        try:
+            ResourceServiceFactory.create("unknown", "00000000-0000-0000-0000-000000000000")
+        except Exception as create_error:
+            test_error = create_error
+
+        self.assertFalse(test_error is None, "Expected error to be thrown for invalid provider")

--- a/tests/test_resource_storage.py
+++ b/tests/test_resource_storage.py
@@ -1,0 +1,63 @@
+import os
+
+from cloud_scanner.services.resource_storage import ResourceStorage
+from .unittest_base import TestCase, FakeQueueMessage
+
+
+class ResourceStorageTest(TestCase):
+    def test_process_queue_message_with_zero_resources(self):
+        os.environ["PROVIDER_LIST"] = "simulator"
+
+        json_data = '[]'
+        message = FakeQueueMessage(bytes(json_data, 'utf-8'))
+        resource_written = ResourceStorage.process_queue_message(message)
+
+        self.assertEqual(0, resource_written)
+
+    def test_process_queue_message_with_single_resource(self):
+        os.environ["PROVIDER_LIST"] = "simulator"
+
+        json_data = '''
+            [{
+                "id": "00000000-0000-0000-0000-000000000123",
+                "accountId": "00000000-0000-0000-0000-000000000001",
+                "providerType": "simulator",
+                "type": "vm",
+                "name": "MyResource",
+                "group": "MyGroup",
+                "location": "WestUS"
+            }]
+        '''
+
+        message = FakeQueueMessage(bytes(json_data, 'utf-8'))
+        resource_written = ResourceStorage.process_queue_message(message)
+
+        self.assertEqual(1, resource_written)
+
+    def test_process_queue_message_with_multiple_resources(self):
+        os.environ["PROVIDER_LIST"] = "simulator"
+
+        json_data = '''
+            [{
+                "id": "00000000-0000-0000-0000-000000000123",
+                "accountId": "00000000-0000-0000-0000-000000000001",
+                "providerType": "simulator",
+                "type": "vm",
+                "name": "MyResource",
+                "group": "MyGroup",
+                "location": "WestUS"
+            },
+            {
+                "id": "00000000-0000-0000-0000-000000000124",
+                "accountId": "00000000-0000-0000-0000-000000000002",
+                "providerType": "simulator",
+                "type": "vm",
+                "name": "MyResource2",
+                "group": "MyGroup2",
+                "location": "EastUS"
+            }]
+        '''
+        message = FakeQueueMessage(bytes(json_data, 'utf-8'))
+        resource_written = ResourceStorage.process_queue_message(message)
+
+        self.assertEqual(2, resource_written)

--- a/tests/test_resource_storage_factory.py
+++ b/tests/test_resource_storage_factory.py
@@ -1,0 +1,46 @@
+import os
+
+from cloud_scanner.contracts.resource_storage_factory import ResourceStorageFactory, register_resource_storage
+from .unittest_base import TestCase
+from unittest.mock import patch
+
+def create_func():
+    return ResourceStorageMock()
+
+
+@register_resource_storage('test', create_func)
+class ResourceStorageMock():
+    pass
+    
+
+class TestResourceStorageFactory(TestCase):
+    def test_simulator_resource_storage(self):
+        os.environ["RESOURCE_STORAGE_TYPE"] = "simulator"
+
+        resource_storage = ResourceStorageFactory.create()
+        self.assertIsNotNone(resource_storage)
+        self.assertEqual(type(resource_storage).__name__, "TableStorageSimulator")
+
+    @patch.object(ResourceStorageFactory, 'register_factory')
+    def test_register_resource_storage_decorator(self, mock_register_factory):
+        os.environ["RESOURCE_STORAGE_TYPE"] = "test"
+        
+        decorator = register_resource_storage('test', create_func)
+        decorator(ResourceStorageFactory)
+
+        mock_register_factory.assert_called_once_with('test', create_func)
+
+        resource_service = ResourceStorageFactory.create()
+        self.assertIsNotNone(resource_service)
+        self.assertEqual(type(resource_service).__name__, "ResourceStorageMock")
+
+    def test_unknown_provider(self):
+        os.environ["RESOURCE_STORAGE_TYPE"] = "unknown"
+        test_error = None
+
+        try:
+            ResourceStorageFactory.create()
+        except Exception as create_error:
+            test_error = create_error
+
+        self.assertFalse(test_error is None, "Expected error to be thrown for invalid provider")

--- a/tests/test_resource_tagger.py
+++ b/tests/test_resource_tagger.py
@@ -1,0 +1,97 @@
+import os
+
+from cloud_scanner.simulators import ResourceServiceSimulator
+from cloud_scanner.services.resource_tagger import ResourceTagger, ResourceTagProcessor
+from .unittest_base import TestCase, FakeQueueMessage
+
+
+class ResourceTaggerTest(TestCase):
+    def setUp(self):
+        os.environ["RESOURCE_STORAGE_TYPE"] = "simulator"
+
+    def test_process_queue_message(self):
+        os.environ["PROVIDER_LIST"] = "simulator"
+
+        json_data = '''
+            {
+                "resource": {
+                    "id": "00000000-0000-0000-0000-000000000123",
+                    "type": "vm",
+                    "group": "MyGroup",
+                    "name": "MyResource",
+                    "location": "WestUS",
+                    "providerType": "simulator",
+                    "accountId": "00000000-0000-0000-0000-000000000001"
+                },
+                "tags": {
+                    "a": "1",
+                    "b": "2"
+                }
+            }
+        '''
+        message = FakeQueueMessage(bytes(json_data, 'utf-8'))
+        result = ResourceTagger.process_queue_message(message)
+
+        self.assertEqual(2, result[0])
+        self.assertEqual(0, result[1])
+
+    def test_scanner_multiple_write(self):
+        target_tags = {
+            'tag1': 'value',
+            'tag2': 'value'
+        }
+
+        resource_service = ResourceServiceSimulator()
+        tag_processor = ResourceTagProcessor(resource_service)
+
+        resource = resource_service.get_resources()[0]
+
+        tag_processor.execute(resource, target_tags, True)
+
+        assert(tag_processor.tags_written == 2)
+        assert(tag_processor.tags_skipped == 0)
+
+    def test_scanner_overwrite(self):
+        test_tag_name = 'testTag1'
+        test_tag_value = 'testTag1Value'
+        test_tag_default_value = 'default'
+
+        target_tags = dict()
+        target_tags[test_tag_name] = test_tag_value
+
+        resource_service = ResourceServiceSimulator()
+        tag_processor = ResourceTagProcessor(resource_service)
+
+        resource = resource_service.get_resources()[0]
+
+        # Test does overwrite
+
+        resource.tags = target_tags.copy()
+        resource.tags[test_tag_name] = test_tag_default_value
+
+        tag_processor.execute(resource, target_tags, True)
+
+        assert(tag_processor.tags_written == 1)
+        assert(tag_processor.tags_skipped == 0)
+        assert(resource.tags[test_tag_name] == test_tag_value)
+
+        # Test does not overwrite
+
+        resource.tags = target_tags.copy()
+        resource.tags[test_tag_name] = test_tag_default_value
+
+        tag_processor.reset()
+        tag_processor.execute(resource, target_tags, False)
+
+        assert(tag_processor.tags_written == 0)
+        assert(tag_processor.tags_skipped == 1)
+        assert(resource.tags[test_tag_name] == test_tag_default_value)
+
+    def test_process_rules(self):
+        os.environ["TAG_UPDATES_QUEUE_NAME"] = "resource-tag-updates"
+        os.environ["QUEUE_TYPE"] = "simulator"
+
+
+        processed = ResourceTagger.process_tag_rules()
+
+        self.assertEqual(10, processed)

--- a/tests/test_rule_factory.py
+++ b/tests/test_rule_factory.py
@@ -1,0 +1,33 @@
+import os
+
+from cloud_scanner.contracts import RuleFactory, register_rule
+from .unittest_base import TestCase
+from unittest.mock import patch
+
+def create_func():
+    return MockRule()
+
+class MockRule:
+    pass
+
+class TestRuleFactory(TestCase):
+    def setUp(self):
+        os.environ["TAG_UPDATES_QUEUE_NAME"] = "resource-tag-updates"
+        os.environ["QUEUE_TYPE"] = "simulator"
+
+    def test_get_all_rules(self):
+        rules = RuleFactory.get_rules()
+
+        self.assertEqual(4, len(rules))
+
+    @patch.object(RuleFactory, 'register_rule')
+    def test_register_rule_decorator(self, register_rule_mock):
+        decorator = register_rule(create_func)
+        decorator(RuleFactory)
+
+        register_rule_mock.assert_called_once()
+
+    def test_get_rules(self):
+        rules = RuleFactory.get_rules()
+        self.assertGreater(len(rules), 0)
+

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,45 @@
+import os
+
+from cloud_scanner.simulators import MockBlobStorageSimulator
+from cloud_scanner.services.task_scheduler import TaskScheduler
+from cloud_scanner.contracts import CloudConfigReader
+from .unittest_base import TestCase
+
+
+class TestScheduler(TestCase):
+    def setUp(self):
+        os.environ["STORAGE_CONTAINER_TYPE"] = "simulator"
+        os.environ["QUEUE_TYPE"] = "simulator"
+        os.environ["TASK_QUEUE_NAME"] = "test-queue"
+
+    def read_config(self):
+        container = MockBlobStorageSimulator()
+        config_reader =  CloudConfigReader(container)
+        return config_reader.read_config()
+
+    def test_latest_config_is_picked(self):
+
+        result = self.read_config()
+        self.assertFalse(result is None)
+
+        providers = result['providers']
+        for provider in providers:
+            self.assertFalse(provider is None)
+
+    def test_tasks_are_created(self):
+
+        result = self.read_config()
+        tasks = TaskScheduler._create_tasks('simulator', result["providers"][0])
+        for task in tasks:
+            id = task['subscriptionId']
+            type = task['typeName']
+            self.assertFalse(id is None)
+            self.assertFalse(type is None)
+
+    def test_push_tasks_to_queue(self):
+        # Get expected number of tasks for simulator provider
+        result = self.read_config()
+        tasks = TaskScheduler._create_tasks('simulator', result["providers"][0])
+
+        task_count = TaskScheduler.execute()
+        self.assertEqual(len(tasks), task_count)

--- a/tests/test_storage_container_factory.py
+++ b/tests/test_storage_container_factory.py
@@ -1,0 +1,55 @@
+import os
+
+from cloud_scanner.contracts.storage_container_factory import StorageContainerFactory, register_storage_container
+from .unittest_base import TestCase
+from unittest.mock import patch
+
+def create_func():
+    return StorageContainerMock()
+
+
+@register_storage_container('test', create_func)
+class StorageContainerMock:
+    pass
+
+
+class TestStorageContainerFactory(TestCase):
+    def setUp(self):
+        os.environ["CONFIG_CONTAINER"] = "test-container"
+
+    def test_create_container_simulator(self):
+        os.environ["STORAGE_CONTAINER_TYPE"] = "simulator"
+
+        container = StorageContainerFactory.create()
+        self.assertIsNotNone(container)
+        self.assertEqual(type(container).__name__, "MockBlobStorageSimulator")
+
+    @patch.object(StorageContainerFactory, 'register_factory')
+    def test_register_storage_container_decorator(self, mock_register_factory):
+        os.environ["STORAGE_CONTAINER_TYPE"] = "test"
+        
+        decorator = register_storage_container('test', create_func)
+        decorator(StorageContainerFactory)
+
+        mock_register_factory.assert_called_once_with('test', create_func)
+
+        container = StorageContainerFactory.create()
+        self.assertIsNotNone(container)
+        self.assertEqual(type(container).__name__, "StorageContainerMock")
+
+    def test_unknown_provider(self):
+        os.environ["STORAGE_CONTAINER_TYPE"] = "unknown"
+        test_error = None
+
+        try:
+            StorageContainerFactory.create()
+        except Exception as create_error:
+            test_error = create_error
+
+        self.assertFalse(test_error is None, "Expected error to be thrown for invalid provider")
+
+
+        
+
+
+

--- a/tests/test_table_storage.py
+++ b/tests/test_table_storage.py
@@ -1,0 +1,38 @@
+import json
+import uuid
+
+from cloud_scanner.simulators import TableStorageSimulator, ResourceServiceSimulator
+from .unittest_base import TestCase
+
+
+class TestTableStorage(TestCase):
+
+    def test_entry_is_inserted(self):
+
+        storage_table = TableStorageSimulator()
+        resource_service = ResourceServiceSimulator()
+        resources = resource_service.get_resources()
+
+        for resource in resources:
+            resource_raw = resource.to_str()
+            data = json.loads(resource_raw)
+
+            # insert the entry onto Cosmos
+            storage_table.write(resource)
+
+            # for data in datastore:
+            location = data['location']
+
+            # save partition and row key for access later
+            partition_key = location
+            row_key = str(uuid.uuid3(uuid.NAMESPACE_DNS, data['id']))
+
+            # verify the entry was written to the table
+            retrieved_entry = None
+            retrieved_entry = storage_table.query(partition_key, row_key)
+
+            # verify the entry was inserted on Cosmos
+            self.assertIsNotNone(retrieved_entry, "No entry was inserted on Cosmos")
+
+            # delete the entry for good practice
+            storage_table.delete(partition_key, row_key)

--- a/tests/unittest_base.py
+++ b/tests/unittest_base.py
@@ -1,0 +1,18 @@
+import unittest
+import json
+
+# Helper to fake an Azure Queue Message
+class FakeQueueMessage:
+    def __init__(self, msg):
+        self._msg = msg
+    
+    def get_body(self):
+        return self._msg
+    
+    def get_json(self):
+        return json.loads(self.get_body().decode("utf-8"))
+
+class TestCase(unittest.TestCase):
+
+    def _use_adapters(self):
+        return False


### PR DESCRIPTION
- Moved simulators to core `cloud-scanner` from `cloud-scanner-azure`
- Moved many tests from core to `cloud-scanner` from `cloud-scanner-azure`